### PR TITLE
Fix Java books list link sintax

### DIFF
--- a/books/java.md
+++ b/books/java.md
@@ -1,1 +1,1 @@
-- (*Think Java* by Allen Downey and Chris Mayfield)[https://greenteapress.com/wp/think-java]: Introduction to computer science and programming intended for people with little or no experience.
+- [*Think Java* by Allen Downey and Chris Mayfield](https://greenteapress.com/wp/think-java): Introduction to computer science and programming intended for people with little or no experience.


### PR DESCRIPTION
Link parentheses where not placed correctly ()[] instead []()