### PR TITLE
Fix link in object oriented books list

### DIFF
--- a/books/object_oriented.md
+++ b/books/object_oriented.md
@@ -1,2 +1,2 @@
-- (*Object Design—Rebecca* by Wirfs-Brock and Alan McKean)[https://www.informit.com/promotions/object-design-142314]: classic text that explores strategies for selecting candidate objects and developing a collaboration models.
+- [*Object Design—Rebecca* by Wirfs-Brock and Alan McKean](https://www.informit.com/promotions/object-design-142314): classic text that explores strategies for selecting candidate objects and developing a collaboration models.
     


### PR DESCRIPTION
Wrong parenthesis location in book link, ()[] instead []()